### PR TITLE
Moved navbar load to head of page

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,14 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>myopic appliance</title>
     <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-slate-800 text-slate-100 px-4 lg:px-20">
-    <div id="navbar"></div>
-    <div class="p-6">
-        <div id="content" class="flex items-center justify-left text-3xl py-10">
-            <p>About test test test</p>
-        </div>
-    </div>
     <script>
         // load the navbar
         document.addEventListener('DOMContentLoaded', function() {
@@ -23,5 +15,13 @@
               });
         });
       </script> 
+</head>
+<body class="bg-slate-800 text-slate-100 px-4 lg:px-20">
+    <div id="navbar"></div>
+    <div class="p-6">
+        <div id="content" class="flex items-center justify-left text-3xl py-10">
+            <p>About test test test</p>
+        </div>
+    </div>
 </body>
 </html>

--- a/appliance.html
+++ b/appliance.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>myopic appliance</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      // load the navbar
+      document.addEventListener('DOMContentLoaded', function() {
+          fetch('navbar.html')
+            .then(response => response.text())
+            .then(data => {
+              document.getElementById('navbar').innerHTML = data;
+            });
+      });
+    </script> 
 </head>
 <body class="bg-slate-800 text-slate-100 px-4 lg:px-20">
     <div id="navbar"></div>
@@ -24,16 +34,6 @@
         <div id="content" class="flex items-center justify-left text-3xl py-10"></div>
         <div id="nounsGrid" class="text-center my-2 grid-cols-5"></div>
     </div>
-    <script>
-        // load the navbar
-        document.addEventListener('DOMContentLoaded', function() {
-            fetch('navbar.html')
-              .then(response => response.text())
-              .then(data => {
-                document.getElementById('navbar').innerHTML = data;
-              });
-        });
-      </script> 
     <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>myopic appliance</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        // load the navbar
+        document.addEventListener('DOMContentLoaded', function() {
+            fetch('navbar.html')
+              .then(response => response.text())
+              .then(data => {
+                document.getElementById('navbar').innerHTML = data;
+              });
+        });
+      </script> 
 </head>
 <body class="bg-slate-800 text-slate-100 px-4 lg:px-20">
     <div id="navbar"></div>
@@ -41,15 +51,6 @@
 
         </div>
     </div>
-    <script>
-        // load the navbar
-        document.addEventListener('DOMContentLoaded', function() {
-            fetch('navbar.html')
-              .then(response => response.text())
-              .then(data => {
-                document.getElementById('navbar').innerHTML = data;
-              });
-        });
-      </script> 
+
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -7,6 +7,6 @@
     }
   }
   
-  .animate-strike {
+.animate-strike {
     animation: strikeThrough 0.5s linear forwards;
-  }
+  }  


### PR DESCRIPTION
This fixed the flickering of pages upon reload by moving code that inserts the navbar into the head, rather than at the end of the body.